### PR TITLE
Error checking, setSMUXLowChannels() rearranging, read all channels while looping, fix of setBank()

### DIFF
--- a/Adafruit_AS7341.cpp
+++ b/Adafruit_AS7341.cpp
@@ -202,8 +202,8 @@ bool Adafruit_AS7341::checkReadingProgress() {
     _readingState = AS7341_WAITING_DONE;
     Adafruit_BusIO_Register channel_data_reg =
         Adafruit_BusIO_Register(i2c_dev, AS7341_CH0_DATA_L, 2);
-    // return low_success &&			//low_success is lost since it was last
-    // call
+    // return low_success &&			//low_success is lost since it was
+    // last call
     channel_data_reg.read((uint8_t *)&_channel_readings[6], 12);
     return true;
   }

--- a/Adafruit_AS7341.cpp
+++ b/Adafruit_AS7341.cpp
@@ -167,7 +167,7 @@ bool Adafruit_AS7341::startReading(void) {
  * 
  * @return true: reading is complete false: reading is incomplete (or failed)
  */
-bool Adafruit_AS7341::checkReadingProgress() {
+bool Adafruit_AS7341::checkReadingProgress() {	
   if(_readingState == AS7341_WAITING_START)
   {
 	  setSMUXLowChannels(true);		//Configure SMUX to read low channels
@@ -179,7 +179,7 @@ bool Adafruit_AS7341::checkReadingProgress() {
   if(!getIsDataReady() || _readingState == AS7341_WAITING_DONE)
 	  return false;
   
-  if(_readingState == AS7341_WAITING_LOW)
+  if(_readingState == AS7341_WAITING_LOW)	//Check of getIsDataRead() is already done
   {
 	  Adafruit_BusIO_Register channel_data_reg = Adafruit_BusIO_Register(i2c_dev, AS7341_CH0_DATA_L, 2);  
 
@@ -192,13 +192,16 @@ bool Adafruit_AS7341::checkReadingProgress() {
 	  return false;
   }
   
-  if(_readingState == AS7341_WAITING_HIGH)
+  if(_readingState == AS7341_WAITING_HIGH)	//Check of getIsDataRead() is already done
   {
 	_readingState = AS7341_WAITING_DONE;	
 	Adafruit_BusIO_Register channel_data_reg = Adafruit_BusIO_Register(i2c_dev, AS7341_CH0_DATA_L, 2);
 	// return low_success &&			//low_success is lost since it was last call
-    return channel_data_reg.read((uint8_t *)&_channel_readings[6], 12);	
+    channel_data_reg.read((uint8_t *)&_channel_readings[6], 12);	
+	return true;
   }
+  
+  return false;
 }
 
 /**
@@ -209,7 +212,7 @@ bool Adafruit_AS7341::checkReadingProgress() {
  * @return true: success false: failure
  */
 bool Adafruit_AS7341::getAllChannels(uint16_t *readings_buffer) {
-  for(int i=0; i<11; i++)
+  for(int i=0; i<12; i++)
 	readings_buffer[i] = _channel_readings[i];
   return true;
 }
@@ -453,7 +456,9 @@ bool Adafruit_AS7341::enableLED(bool enable_led) {
       Adafruit_BusIO_RegisterBits(&led_reg, 1, 7);
 
   setBank(true); // Access 0x60-0x74
-  return (led_sel_bit.write(enable_led) && led_act_bit.write(enable_led));
+  bool result = led_sel_bit.write(enable_led) && led_act_bit.write(enable_led);
+  setBank(false);	//Access registers 0x80 and above (default)
+  return result;
 }
 
 /**
@@ -482,7 +487,9 @@ bool Adafruit_AS7341::setLEDCurrent(uint16_t led_current_ma) {
   Adafruit_BusIO_RegisterBits led_current_bits =
       Adafruit_BusIO_RegisterBits(&led_reg, 7, 0);
 
-  return led_current_bits.write((uint8_t)((led_current_ma - 4) / 2));
+  bool result = led_current_bits.write((uint8_t)((led_current_ma - 4) / 2));
+  setBank(false);	//Access registers 0x80 and above (default)
+  return result;
 }
 
 /**

--- a/Adafruit_AS7341.h
+++ b/Adafruit_AS7341.h
@@ -237,6 +237,13 @@ typedef enum {
   AS7341_GPIO_INPUT,  ///< The GPIO Pin is set as a high-impedence input
 } as7341_gpio_dir_t;
 
+typedef enum {
+  AS7341_WAITING_START, //
+  AS7341_WAITING_LOW, //
+  AS7341_WAITING_HIGH,  //
+  AS7341_WAITING_DONE,  //
+} as7341_waiting_t;
+
 class Adafruit_AS7341;
 
 /*!
@@ -260,6 +267,11 @@ public:
   void delayForData(int waitTime=0);
   uint16_t readChannel(as7341_adc_channel_t channel);
   uint16_t getChannel(as7341_color_channel_t channel);
+  
+  bool startReading(void);
+  bool checkReadingProgress();
+  bool getAllChannels(uint16_t *readings_buffer);
+  
 
   uint16_t detectFlickerHz(void);
 
@@ -321,6 +333,7 @@ private:
   void writeRegister(byte addr, byte val);
   void setSMUXLowChannels(bool f1_f4);
   uint16_t _channel_readings[12];
+  as7341_waiting_t _readingState;
 };
 
 #endif

--- a/Adafruit_AS7341.h
+++ b/Adafruit_AS7341.h
@@ -239,7 +239,7 @@ typedef enum {
 
 typedef enum {
   AS7341_WAITING_START, //
-  AS7341_WAITING_LOW, //
+  AS7341_WAITING_LOW,   //
   AS7341_WAITING_HIGH,  //
   AS7341_WAITING_DONE,  //
 } as7341_waiting_t;
@@ -264,14 +264,13 @@ public:
 
   bool readAllChannels(void);
   bool readAllChannels(uint16_t *readings_buffer);
-  void delayForData(int waitTime=0);
+  void delayForData(int waitTime = 0);
   uint16_t readChannel(as7341_adc_channel_t channel);
   uint16_t getChannel(as7341_color_channel_t channel);
-  
+
   bool startReading(void);
   bool checkReadingProgress();
   bool getAllChannels(uint16_t *readings_buffer);
-  
 
   uint16_t detectFlickerHz(void);
 

--- a/Adafruit_AS7341.h
+++ b/Adafruit_AS7341.h
@@ -257,6 +257,7 @@ public:
 
   bool readAllChannels(void);
   bool readAllChannels(uint16_t *readings_buffer);
+  void delayForData(int waitTime=0);
   uint16_t readChannel(as7341_adc_channel_t channel);
   uint16_t getChannel(as7341_color_channel_t channel);
 

--- a/examples/reading_while_looping/reading_while_looping.ino
+++ b/examples/reading_while_looping/reading_while_looping.ino
@@ -1,0 +1,100 @@
+/* This example shows to to read all channels from the AS7341 and print out reported values, but allow loop() to run while waiting for the readings */
+#include <Adafruit_AS7341.h>
+
+Adafruit_AS7341 as7341;
+//TwoWire myWire2(2);
+uint16_t readings[12];
+
+void setup() 
+{
+  Serial.begin(115200);
+
+  // Wait for communication with the host computer serial monitor
+  while (!Serial) 
+  {
+    Serial.println("Failed, looping forever");
+    delay(1000);  
+  }
+
+//  myWire2.begin();
+  Wire.begin();
+  delay(20);
+  
+//  if (!as7341.begin(0x39, &myWire2)){ //Use TwoWire I2C port
+  if (!as7341.begin()){ //Default address and I2C port
+    Serial.println("Could not find AS7341");
+    while (1) { delay(10); }
+  }
+  
+  as7341.setATIME(35);
+  as7341.setASTEP(10000); //This combination of ATIME and ASTEP gives an integration time of about 1sec, so with two integrations, that's 2 seconds for a complete set of readings
+  as7341.setGain(AS7341_GAIN_256X);
+  
+  as7341.startReading();
+}
+
+void loop() 
+{
+  bool timeOutFlag = yourTimeOutCheck();
+  if(as7341.checkReadingProgress() || timeOutFlag )
+  {
+    if(timeOutFlag)
+    {} //Recover/restart/retc.
+    
+    Serial.println("\nAha, the reading we started a few cycles back is finished, here it is:");
+    //IMPORTANT: make sure readings is a uint16_t array of size 12, otherwise strange things may happen
+    as7341.getAllChannels(readings);  //Calling this any other time may give you old data
+    printReadings();
+
+    Serial.println("\nLet's try a reading using readAllChannels (inbuilt delay), waiting...");
+    if (!as7341.readAllChannels(readings))
+      Serial.println("Error reading all channels!");
+    else
+      printReadings();
+    Serial.println("Guess we'll start another reading right away but do some work in the meantime\n");
+    as7341.startReading();
+  }
+
+  //Do some work in the loop
+  Serial.println("Working hard");
+  delay(500); //Hardly working
+}
+
+bool yourTimeOutCheck()
+{
+  //Fill this in to prevent the possibility of getting stuck forever if you missed the result, or whatever
+  return false;
+}
+
+void printReadings()
+{
+  Serial.print("ADC0/F1 415nm : ");
+  Serial.println(readings[0]);
+  Serial.print("ADC1/F2 445nm : ");
+  Serial.println(readings[1]);
+  Serial.print("ADC2/F3 480nm : ");
+  Serial.println(readings[2]);
+  Serial.print("ADC3/F4 515nm : ");
+  Serial.println(readings[3]);
+  Serial.print("ADC0/F5 555nm : ");
+
+  /* 
+  // we skip the first set of duplicate clear/NIR readings
+  Serial.print("ADC4/Clear-");
+  Serial.println(readings[4]);
+  Serial.print("ADC5/NIR-");
+  Serial.println(readings[5]);
+  */
+  
+  Serial.println(readings[6]);
+  Serial.print("ADC1/F6 590nm : ");
+  Serial.println(readings[7]);
+  Serial.print("ADC2/F7 630nm : ");
+  Serial.println(readings[8]);
+  Serial.print("ADC3/F8 680nm : ");
+  Serial.println(readings[9]);
+  Serial.print("ADC4/Clear    : ");
+  Serial.println(readings[10]);
+  Serial.print("ADC5/NIR      : ");
+  Serial.println(readings[11]);
+}


### PR DESCRIPTION
•	Moved the initiating of a reading and waiting for the results out of setSMUXLowChannels(), so that function can be used for a non-waiting read (next pull request)
•	Add a potential escape from while loops if there is a sensor error and data never becomes available (a bit of a cop-out using a default value of 0/forever, but might be useful in other stuff to be added).  A better solution would be to use the expected integration time, but this would need storage of ASTEP and ATIME values, or perhaps doing a read.
•	Query as to whether the 500ms delay in flicker detection is needed to be that long
