### PR TITLE
Add getters and conversion method to basic counts

### DIFF
--- a/Adafruit_AS7341.cpp
+++ b/Adafruit_AS7341.cpp
@@ -715,7 +715,6 @@ bool Adafruit_AS7341::setATIME(uint8_t atime_value) {
   return atime_reg.write(atime_value);
 }
 
-
 /**
  * @brief Returns the integration time step count
  *
@@ -768,7 +767,6 @@ bool Adafruit_AS7341::setGain(as7341_gain_t gain_value) {
   // AGAIN bitfield is only[0:4] but the rest is empty
 }
 
-
 /**
  * @brief Returns the ADC gain multiplier
  *
@@ -777,17 +775,16 @@ bool Adafruit_AS7341::setGain(as7341_gain_t gain_value) {
 as7341_gain_t Adafruit_AS7341::getGain() {
   Adafruit_BusIO_Register cfg1_reg =
       Adafruit_BusIO_Register(i2c_dev, AS7341_CFG1);
-  return (as7341_gain_t) cfg1_reg.read();
+  return (as7341_gain_t)cfg1_reg.read();
 }
 
-
 /**
-  * @brief Returns the integration time
-  *
-  * The integration time is `(ATIME + 1) * (ASTEP + 1) * 2.78µS`
-  *
-  * @return long The current integration time in ms
-  */
+ * @brief Returns the integration time
+ *
+ * The integration time is `(ATIME + 1) * (ASTEP + 1) * 2.78µS`
+ *
+ * @return long The current integration time in ms
+ */
 long Adafruit_AS7341::getTINT() {
   uint16_t astep = getASTEP();
   uint8_t atime = getATIME();
@@ -796,51 +793,51 @@ long Adafruit_AS7341::getTINT() {
 }
 
 /**
-  * @brief Converts raw ADC values to basic counts
-  *
-  * The basic counts are `RAW/(GAIN * TINT)`
-  *
-  * @return float The basic counts
-  */
+ * @brief Converts raw ADC values to basic counts
+ *
+ * The basic counts are `RAW/(GAIN * TINT)`
+ *
+ * @return float The basic counts
+ */
 float Adafruit_AS7341::toBasicCounts(uint16_t raw) {
   float gain_val = 0;
   as7341_gain_t gain = getGain();
   switch (gain) {
-    case AS7341_GAIN_0_5X:
-      gain_val = 0.5;
-      break;
-    case AS7341_GAIN_1X:
-      gain_val = 1;
-      break;
-    case AS7341_GAIN_2X:
-      gain_val = 2;
-      break;
-    case AS7341_GAIN_4X:
-      gain_val = 4;
-      break;
-    case AS7341_GAIN_8X:
-      gain_val = 8;
-      break;
-    case AS7341_GAIN_16X:
-      gain_val = 16;
-      break;
-    case AS7341_GAIN_32X:
-      gain_val = 32;
-      break;
-    case AS7341_GAIN_64X:
-      gain_val = 64;
-      break;
-    case AS7341_GAIN_128X:
-      gain_val = 128;
-      break;
-    case AS7341_GAIN_256X:
-      gain_val = 256;
-      break;
-    case AS7341_GAIN_512X:
-      gain_val = 512;
-      break;
+  case AS7341_GAIN_0_5X:
+    gain_val = 0.5;
+    break;
+  case AS7341_GAIN_1X:
+    gain_val = 1;
+    break;
+  case AS7341_GAIN_2X:
+    gain_val = 2;
+    break;
+  case AS7341_GAIN_4X:
+    gain_val = 4;
+    break;
+  case AS7341_GAIN_8X:
+    gain_val = 8;
+    break;
+  case AS7341_GAIN_16X:
+    gain_val = 16;
+    break;
+  case AS7341_GAIN_32X:
+    gain_val = 32;
+    break;
+  case AS7341_GAIN_64X:
+    gain_val = 64;
+    break;
+  case AS7341_GAIN_128X:
+    gain_val = 128;
+    break;
+  case AS7341_GAIN_256X:
+    gain_val = 256;
+    break;
+  case AS7341_GAIN_512X:
+    gain_val = 512;
+    break;
   }
-  return raw/(gain_val * (getATIME()+1) * (getASTEP()+1) * 2.78 / 1000);
+  return raw / (gain_val * (getATIME() + 1) * (getASTEP() + 1) * 2.78 / 1000);
 }
 
 /**

--- a/Adafruit_AS7341.cpp
+++ b/Adafruit_AS7341.cpp
@@ -797,6 +797,8 @@ long Adafruit_AS7341::getTINT() {
  *
  * The basic counts are `RAW/(GAIN * TINT)`
  *
+ * @param raw The raw ADC values to convert
+ *
  * @return float The basic counts
  */
 float Adafruit_AS7341::toBasicCounts(uint16_t raw) {

--- a/Adafruit_AS7341.cpp
+++ b/Adafruit_AS7341.cpp
@@ -715,6 +715,20 @@ bool Adafruit_AS7341::setATIME(uint8_t atime_value) {
   return atime_reg.write(atime_value);
 }
 
+
+/**
+ * @brief Returns the integration time step count
+ *
+ * Total integration time will be `(ATIME + 1) * (ASTEP + 1) * 2.78µS`
+ *
+ * @return uint8_t The current integration time step count
+ */
+uint8_t Adafruit_AS7341::getATIME() {
+  Adafruit_BusIO_Register atime_reg =
+      Adafruit_BusIO_Register(i2c_dev, AS7341_ATIME);
+  return atime_reg.read();
+}
+
 /**
  * @brief Sets the integration time step size
  *
@@ -729,7 +743,20 @@ bool Adafruit_AS7341::setASTEP(uint16_t astep_value) {
 }
 
 /**
- * @brief Set the ADC gain multiplier
+ * @brief Returns the integration time step size
+ *
+ * Step size is `(astep_value+1) * 2.78 uS`
+ *
+ * @return uint16_t The current integration time step size
+ */
+uint16_t Adafruit_AS7341::getASTEP() {
+  Adafruit_BusIO_Register astep_reg =
+      Adafruit_BusIO_Register(i2c_dev, AS7341_ASTEP_L, 2, LSBFIRST);
+  return astep_reg.read();
+}
+
+/**
+ * @brief Sets the ADC gain multiplier
  *
  * @param gain_value The gain amount. must be an `as7341_gain_t`
  * @return true: success false: failure
@@ -739,6 +766,81 @@ bool Adafruit_AS7341::setGain(as7341_gain_t gain_value) {
       Adafruit_BusIO_Register(i2c_dev, AS7341_CFG1);
   return cfg1_reg.write(gain_value);
   // AGAIN bitfield is only[0:4] but the rest is empty
+}
+
+
+/**
+ * @brief Returns the ADC gain multiplier
+ *
+ * @return as7341_gain_t The current ADC gain multiplier
+ */
+as7341_gain_t Adafruit_AS7341::getGain() {
+  Adafruit_BusIO_Register cfg1_reg =
+      Adafruit_BusIO_Register(i2c_dev, AS7341_CFG1);
+  return (as7341_gain_t) cfg1_reg.read();
+}
+
+
+/**
+  * @brief Returns the integration time
+  *
+  * The integration time is `(ATIME + 1) * (ASTEP + 1) * 2.78µS`
+  *
+  * @return long The current integration time in ms
+  */
+long Adafruit_AS7341::getTINT() {
+  uint16_t astep = getASTEP();
+  uint8_t atime = getATIME();
+
+  return (atime + 1) * (astep + 1) * 2.78 / 1000;
+}
+
+/**
+  * @brief Converts raw ADC values to basic counts
+  *
+  * The basic counts are `RAW/(GAIN * TINT)`
+  *
+  * @return float The basic counts
+  */
+float Adafruit_AS7341::toBasicCounts(uint16_t raw) {
+  float gain_val = 0;
+  as7341_gain_t gain = getGain();
+  switch (gain) {
+    case AS7341_GAIN_0_5X:
+      gain_val = 0.5;
+      break;
+    case AS7341_GAIN_1X:
+      gain_val = 1;
+      break;
+    case AS7341_GAIN_2X:
+      gain_val = 2;
+      break;
+    case AS7341_GAIN_4X:
+      gain_val = 4;
+      break;
+    case AS7341_GAIN_8X:
+      gain_val = 8;
+      break;
+    case AS7341_GAIN_16X:
+      gain_val = 16;
+      break;
+    case AS7341_GAIN_32X:
+      gain_val = 32;
+      break;
+    case AS7341_GAIN_64X:
+      gain_val = 64;
+      break;
+    case AS7341_GAIN_128X:
+      gain_val = 128;
+      break;
+    case AS7341_GAIN_256X:
+      gain_val = 256;
+      break;
+    case AS7341_GAIN_512X:
+      gain_val = 512;
+      break;
+  }
+  return raw/(gain_val * (getATIME()+1) * (getASTEP()+1) * 2.78 / 1000);
 }
 
 /**

--- a/Adafruit_AS7341.h
+++ b/Adafruit_AS7341.h
@@ -255,6 +255,13 @@ public:
   bool setATIME(uint8_t atime_value);
   bool setGain(as7341_gain_t gain_value);
 
+  uint16_t getASTEP();
+  uint8_t getATIME();
+  as7341_gain_t getGain();
+
+  long getTINT();
+  float toBasicCounts(uint16_t raw);
+
   bool readAllChannels(void);
   bool readAllChannels(uint16_t *readings_buffer);
   uint16_t readChannel(as7341_adc_channel_t channel);

--- a/examples/basic_counts/basic_counts.ino
+++ b/examples/basic_counts/basic_counts.ino
@@ -1,0 +1,76 @@
+/** This example will read all channels from the AS7341.
+  * The raw ADC values will then be converted to basic counts
+  * according to the sensor's appliation note:
+  * 
+  * https://ams.com/documents/20143/36005/AS7341_AN000633_1-00.pdf/fc552673-9800-8d60-372d-fc67cf075740
+  * Section 3.1
+  * 
+  * BasicCounts = RawSensorValue / ( Gain x IntegrationTime )
+  * 
+  * Finally, the converted values are printed out.
+  */
+#include <Adafruit_AS7341.h>
+
+Adafruit_AS7341 as7341;
+
+void setup() {
+  Serial.begin(115200);
+
+  // Wait for communication with the host computer serial monitor
+  while (!Serial) {
+    delay(1);
+  }
+  
+  if (!as7341.begin()){
+    Serial.println("Could not find AS7341");
+    while (1) { delay(10); }
+  }
+  
+  as7341.setATIME(100);
+  as7341.setASTEP(999);
+  as7341.setGain(AS7341_GAIN_256X);
+}
+
+void loop() {
+  // put your main code here, to run repeatedly:
+  uint16_t readings[12];
+  float counts[12];
+
+  if (!as7341.readAllChannels(readings)){
+    Serial.println("Error reading all channels!");
+    return;
+  }
+
+  for(uint8_t i = 0; i < 12; i++) {
+    if(i == 4 || i == 5) continue;
+    // we skip the first set of duplicate clear/NIR readings
+    // (indices 4 and 5)
+    counts[i] = as7341.toBasicCounts(readings[i]);
+  }
+
+  Serial.print("F1 415nm : ");
+  Serial.println(counts[0]);
+  Serial.print("F2 445nm : ");
+  Serial.println(counts[1]);
+  Serial.print("F3 480nm : ");
+  Serial.println(counts[2]);
+  Serial.print("F4 515nm : ");
+  Serial.println(counts[3]);
+  Serial.print("F5 555nm : ");
+  // again, we skip the duplicates  
+  Serial.println(counts[6]);
+  Serial.print("F6 590nm : ");
+  Serial.println(counts[7]);
+  Serial.print("F7 630nm : ");
+  Serial.println(counts[8]);
+  Serial.print("F8 680nm : ");
+  Serial.println(counts[9]);
+  Serial.print("Clear    : ");
+  Serial.println(counts[10]);
+  Serial.print("NIR      : ");
+  Serial.println(counts[11]);
+
+  Serial.println();
+  
+  delay(500);
+}


### PR DESCRIPTION
I've added getter methods for the values ATIME, ASTEP, TINT, and the gain.
Said methods are then used in the new method `toBasicCounts` which converts the values returned by the ADC to "Basic Count" values as described in [the Application Note (Section 3.1) for the AS7341](https://ams.com/documents/20143/36005/AS7341_AN000633_1-00.pdf/fc552673-9800-8d60-372d-fc67cf075740).

None of the already existing code was changed.