### PR TITLE
Custom SMUX configuration

### DIFF
--- a/Adafruit_AS7341.cpp
+++ b/Adafruit_AS7341.cpp
@@ -202,8 +202,8 @@ bool Adafruit_AS7341::checkReadingProgress() {
     _readingState = AS7341_WAITING_DONE;
     Adafruit_BusIO_Register channel_data_reg =
         Adafruit_BusIO_Register(i2c_dev, AS7341_CH0_DATA_L, 2);
-    // return low_success &&			//low_success is lost since it was
-    // last call
+    // return low_success &&			//low_success is lost since it
+    // was last call
     channel_data_reg.read((uint8_t *)&_channel_readings[6], 12);
     return true;
   }

--- a/Adafruit_AS7341.cpp
+++ b/Adafruit_AS7341.cpp
@@ -150,8 +150,6 @@ bool Adafruit_AS7341::readAllChannels(uint16_t *readings_buffer) {
  * @brief starts the process of getting readings from all channels without using
  * delays
  *
- * @param none
- *
  * @return true: success false: failure (a bit arbitrary)
  */
 bool Adafruit_AS7341::startReading(void) {
@@ -165,7 +163,6 @@ bool Adafruit_AS7341::startReading(void) {
  * delays.  Should be called regularly (ie. in loop()) Need to call
  * startReading() to initialise the process Need to call getAllChannels() to
  * transfer the data into an external buffer
- * @param none
  *
  * @return true: reading is complete false: reading is incomplete (or failed)
  */
@@ -229,6 +226,7 @@ bool Adafruit_AS7341::getAllChannels(uint16_t *readings_buffer) {
 /**
  * @brief Delay while waiting for data, with option to time out and recover
  *
+ * @param waitTime the maximum amount of time to wait
  * @return none
  */
 void Adafruit_AS7341::delayForData(int waitTime) {

--- a/Adafruit_AS7341.h
+++ b/Adafruit_AS7341.h
@@ -53,6 +53,7 @@
 #ifndef _ADAFRUIT_AS7341_H
 #define _ADAFRUIT_AS7341_H
 
+#include <Adafruit_AS7341_SMUX.h>
 #include "Arduino.h"
 #include <Adafruit_BusIO_Register.h>
 #include <Adafruit_I2CDevice.h>
@@ -242,10 +243,23 @@ typedef enum {
  */
 typedef enum {
   AS7341_WAITING_START, //
+  AS7341_WAITING_CONTINUE, //
   AS7341_WAITING_LOW,   //
   AS7341_WAITING_HIGH,  //
   AS7341_WAITING_DONE,  //
 } as7341_waiting_t;
+
+/**
+ * @brief Channel groups
+ */
+typedef enum {
+  AS7341_CH_NONE, //
+  AS7341_CH_LOW,   //
+  AS7341_CH_HIGH,  //
+  AS7341_CH_BOTH,  //
+  AS7341_CUSTOM_SMUX,  //
+} as7341_channel_group_t;
+
 
 class Adafruit_AS7341;
 
@@ -271,7 +285,7 @@ public:
   uint16_t readChannel(as7341_adc_channel_t channel);
   uint16_t getChannel(as7341_color_channel_t channel);
 
-  bool startReading(void);
+  bool startReading(as7341_channel_group_t channelsOption = AS7341_CH_BOTH);
   bool checkReadingProgress();
   bool getAllChannels(uint16_t *readings_buffer);
 
@@ -279,6 +293,7 @@ public:
 
   void setup_F1F4_Clear_NIR(void);
   void setup_F5F8_Clear_NIR(void);
+  bool setSMUXCustomChannels();	
 
   void powerEnable(bool enable_power);
   bool enableSpectralMeasurement(bool enable_measurement);
@@ -317,6 +332,15 @@ public:
   bool setGPIOInverted(bool gpio_inverted);
   bool getGPIOValue(void);
   bool setGPIOValue(bool);
+  
+  bool clearSMUXPixelRegistersLocal();
+  bool updateSMUXEntryLocal(byte diodePixel, byte numADC);
+  bool setSMUXADCFromConfigWord(byte inADC, uint32_t wordIn);
+  bool addSMUXPixelToADCword(uint32_t* inputWord, byte inputPixel);
+  bool removeSMUXPixelFromADCword(uint32_t* inputWord, byte inputPixel);
+  uint32_t getSMUXConfigWordForADC(byte inADC);
+  void printLocalSMUXConfig();
+  void printBits(long int n, int numBits);
 
 protected:
   virtual bool _init(int32_t sensor_id);
@@ -335,7 +359,11 @@ private:
   void writeRegister(byte addr, byte val);
   void setSMUXLowChannels(bool f1_f4);
   uint16_t _channel_readings[12];
-  as7341_waiting_t _readingState;
+  as7341_waiting_t _readingState = AS7341_WAITING_DONE;
+  as7341_channel_group_t _channelsOption = AS7341_CH_BOTH;
+  byte SMUXPixelRegistersLocal[SMUX_PIXEL_REG_NUM];
 };
+
+
 
 #endif

--- a/Adafruit_AS7341.h
+++ b/Adafruit_AS7341.h
@@ -8,7 +8,7 @@
  * 	I2C Driver for the Library for the AS7341 11-Channel Spectral Sensor
  *
  * 	This is a library for the Adafruit AS7341 breakout:
- * 	https://www.adafruit.com/product/45XX
+ * 	https://www.adafruit.com/product/4698
  *
  * 	Adafruit invests time and resources providing this open source code,
  *  please support Adafruit and open-source hardware by purchasing products from
@@ -237,6 +237,8 @@ typedef enum {
   AS7341_GPIO_INPUT,  ///< The GPIO Pin is set as a high-impedence input
 } as7341_gpio_dir_t;
 
+/**
+ * @brief Wait states for async reading
 typedef enum {
   AS7341_WAITING_START, //
   AS7341_WAITING_LOW,   //

--- a/Adafruit_AS7341.h
+++ b/Adafruit_AS7341.h
@@ -239,6 +239,7 @@ typedef enum {
 
 /**
  * @brief Wait states for async reading
+ */
 typedef enum {
   AS7341_WAITING_START, //
   AS7341_WAITING_LOW,   //

--- a/Adafruit_AS7341_SMUX.h
+++ b/Adafruit_AS7341_SMUX.h
@@ -1,0 +1,245 @@
+/*!
+ *  @file Adafruit_AS7341_SMUX.h
+
+ *  @mainpage Adafruit AS7341 11-Channel Spectral Sensor
+ *
+ *  @section intro_sec Introduction
+ *
+ * 	I2C Driver for the Library for the AS7341 11-Channel Spectral Sensor
+ *
+ * 	This is a library for the Adafruit AS7341 breakout:
+ * 	https://www.adafruit.com/product/4698
+ *
+ * 	Adafruit invests time and resources providing this open source code,
+ *  please support Adafruit and open-source hardware by purchasing products from
+ * 	Adafruit!
+ *
+ *  @section dependencies Dependencies
+ *  This library depends on the Adafruit BusIO library
+ *
+ *  @section author Author
+ *
+ *  
+ *
+ * 	@section license License
+ *
+ * 	
+ *
+ * 	@section  HISTORY
+ *
+ *     v1.0 - First release
+ */
+
+/*
+  SMUX lookup values transferred from datasheet by Stephen Fordyce, 23/10/2020
+  Refer to document "AS7341_AN000666_1-00 - SMUX Config"
+
+  Development environment specifics: Arduino IDE 1.8.12
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+*/
+
+#ifndef _ADAFRUIT_AS7341_SMUX_H
+#define _ADAFRUIT_AS7341_SMUX_H
+
+#define SMUX_PIXEL_REG_NUM 0x14	//13+1, because 0 isn't used
+
+//Mapping of SMUX pixel names to arbitrary index numbers
+#define PIXEL1 0
+#define PIXEL2 1
+#define PIXEL7 2
+#define PIXEL8 3
+#define PIXEL11 4
+#define PIXEL10 5
+#define PIXEL13 6
+#define PIXEL14 7
+#define PIXEL17 8
+#define PIXEL19 9
+#define PIXEL20 10
+#define PIXEL25 11
+#define PIXEL26 12
+#define PIXEL29 13
+#define PIXEL28 14
+#define PIXEL31 15
+#define PIXEL33 16
+#define PIXEL32 17
+#define PIXEL35 18
+#define PIXEL34 19
+#define PIXEL37 20
+#define PIXEL39 21
+#define PIXEL38 22
+
+#define NUM_PIXELS 23
+///////////////////////////////////////
+
+//Mapping of SMUX pixel names to numbers (in datasheet order)
+//This order is also how the arbitrary pixel indexes are assigned
+#define FX_FLICKER PIXEL39
+#define F1_LEFT PIXEL2 
+#define F3_LEFT PIXEL1 
+#define F5_RIGHT PIXEL19 
+#define F7_RIGHT PIXEL20 
+#define F6_LEFT PIXEL8 
+#define F8_LEFT PIXEL7 
+#define F2_RIGHT PIXEL25 
+#define F4_RIGHT PIXEL26 
+#define F4_LEFT PIXEL11 
+#define F2_LEFT PIXEL10 
+#define F8_RIGHT PIXEL28 
+#define F6_RIGHT PIXEL29 
+#define F7_LEFT PIXEL14 
+#define F5_LEFT PIXEL13 
+#define F3_RIGHT PIXEL31 
+#define F1_RIGHT PIXEL32 
+#define FX_CLEAR_LEFT PIXEL17 
+#define FX_NIR PIXEL38 
+#define FX_CLEAR_RIGHT PIXEL35 
+#define FX_EXT_IN_GPIO PIXEL33 
+#define FX_EXT_IN_INT PIXEL34 
+#define RX_DARK PIXEL37 
+///////////////////////////////////////
+
+
+//Mapping of SMUX pixel numbers to addresses
+#define PIX1_ADDR 0x00
+#define PIX2_ADDR 0x01
+//#define UNUSED_A_ADDR 0x02
+#define PIX7_ADDR 0x03
+#define PIX8_ADDR 0x04
+#define PIX11_ADDR 0x05
+#define PIX10_ADDR 0x05
+#define PIX13_ADDR 0x06
+#define PIX14_ADDR 0x07
+#define PIX17_ADDR 0x08
+#define PIX19_ADDR 0x09
+#define PIX20_ADDR 0x0A
+//#define UNUSED_B_ADDR 0x0B
+#define PIX25_ADDR 0x0C
+#define PIX26_ADDR 0x0D
+#define PIX29_ADDR 0x0E
+#define PIX28_ADDR 0x0E
+#define PIX31_ADDR 0x0F
+#define PIX33_ADDR 0x10
+#define PIX32_ADDR 0x10
+#define PIX35_ADDR 0x11
+#define PIX34_ADDR 0x11
+#define PIX37_ADDR 0x12
+#define PIX39_ADDR 0x13
+#define PIX38_ADDR 0x13
+///////////////////////////////////////
+
+//Mapping of SMUX pixel numbers to address bits
+#define PIX1_POS 6
+#define PIX2_POS 2
+// #define UNUSED_A_POS 2
+#define PIX7_POS 6
+#define PIX8_POS 2
+#define PIX11_POS 6
+#define PIX10_POS 2
+#define PIX13_POS 6
+#define PIX14_POS 2
+#define PIX17_POS 6
+#define PIX19_POS 6
+#define PIX20_POS 2
+// #define UNUSED_B_POS 2
+#define PIX25_POS 6
+#define PIX26_POS 2
+#define PIX29_POS 6
+#define PIX28_POS 2
+#define PIX31_POS 6
+#define PIX33_POS 6
+#define PIX32_POS 2
+#define PIX35_POS 6
+#define PIX34_POS 2
+#define PIX37_POS 6
+#define PIX39_POS 6
+#define PIX38_POS 2
+///////////////////////////////////////
+
+//Definition of SMUX ADC numbers
+#define ADC_DISABLED 0
+#define ADC0 1
+#define ADC1 2
+#define ADC2 3
+#define ADC3 4
+#define ADC4 5
+#define ADC5 6
+///////////////////////////////////////
+
+//Some handy config words
+#define CWORD_NONE 	  0b00000000000000000000000000000000
+#define CWORD_BOTH_F1 0b00000000000000100000000000000010
+#define CWORD_BOTH_F2 0b00000000000000000000100000100000
+#define CWORD_BOTH_F3 0b00000000000000001000000000000001
+#define CWORD_BOTH_F4 0b00000000000000000001000000010000
+#define CWORD_BOTH_F5 0b00000000000000000000001001000000
+#define CWORD_BOTH_F6 0b00000000000000000010000000001000
+#define CWORD_BOTH_F7 0b00000000000000000000010010000000
+#define CWORD_BOTH_F8 0b00000000000000000100000000000100
+#define CWORD_BOTH_CLEAR 0b00000000000001000000000100000000
+#define CWORD_NIR 	  0b00000000010000000000000000000000
+///////////////////////////////////////
+
+//Lookup table for SMUX pixel address
+//Index is SMUX diode, ie. F3_LEFT or PIXEL1)
+const byte pixelAddr[NUM_PIXELS] = {	
+	 PIX1_ADDR,
+	 PIX2_ADDR,
+	 PIX7_ADDR,
+	 PIX8_ADDR,
+	 PIX11_ADDR,
+	 PIX10_ADDR,
+	 PIX13_ADDR,
+	 PIX14_ADDR,
+	 PIX17_ADDR,
+	 PIX19_ADDR,
+	 PIX20_ADDR,
+	 PIX25_ADDR,
+	 PIX26_ADDR,
+	 PIX29_ADDR,
+	 PIX28_ADDR,
+	 PIX31_ADDR,
+	 PIX33_ADDR,
+	 PIX32_ADDR,
+	 PIX35_ADDR,
+	 PIX34_ADDR,
+	 PIX37_ADDR,
+	 PIX39_ADDR,
+	 PIX38_ADDR
+	};
+
+//Lookup table for SMUX pixel address positions within the address byte
+//Index is SMUX diode, ie. F3_LEFT or PIXEL1)
+const byte pixelPos[NUM_PIXELS] = {
+	 PIX1_POS,
+	 PIX2_POS,
+	 PIX7_POS,
+	 PIX8_POS,
+	 PIX11_POS,
+	 PIX10_POS,
+	 PIX13_POS,
+	 PIX14_POS,
+	 PIX17_POS,
+	 PIX19_POS,
+	 PIX20_POS,
+	 PIX25_POS,
+	 PIX26_POS,
+	 PIX29_POS,
+	 PIX28_POS,
+	 PIX31_POS,
+	 PIX33_POS,
+	 PIX32_POS,
+	 PIX35_POS,
+	 PIX34_POS,
+	 PIX37_POS,
+	 PIX39_POS,
+	 PIX38_POS,
+	};
+
+
+
+#endif
+

--- a/README.md
+++ b/README.md
@@ -3,10 +3,13 @@
 This is the Adafruit AS7341 11-Channel Spectral Sensor for Arduino
 
 Tested and works great with the Adafruit AS7341 Breakout Board
-[<img src="assets/board.png?raw=true" width="500px">](https://www.adafruit.com/products/45XX)
+[<img src="assets/board.png?raw=true" width="500px">](https://www.adafruit.com/products/4698)
 This chip uses I2C to communicate, 2 pins are required to interface
 
 Adafruit invests time and resources providing this open source code, please support Adafruit and open-source hardware by purchasing products from Adafruit!
+
+# Installation
+To install, use the Arduino Library Manager and search for "Adafruit AS7341" and install the library.
 
 # Dependencies
 * [Adafruit_BusIO](https://github.com/adafruit/Adafruit_BusIO)
@@ -24,8 +27,24 @@ https://learn.adafruit.com/the-well-automated-arduino-library/doxygen
 
 https://learn.adafruit.com/the-well-automated-arduino-library/doxygen-tips
 
+## Formatting and clang-format
+This library uses [`clang-format`](https://releases.llvm.org/download.html) to standardize the formatting of `.cpp` and `.h` files. 
+Contributions should be formatted using `clang-format`:
+
+The `-i` flag will make the changes to the file.
+```bash
+clang-format -i *.cpp *.h
+```
+If you prefer to make the changes yourself, running `clang-format` without the `-i` flag will print out a formatted version of the file. You can save this to a file and diff it against the original to see the changes.
+
+Note that the formatting output by `clang-format` is what the automated formatting checker will expect. Any diffs from this formatting will result in a failed build until they are addressed. **Using the `-i` flag is highly recommended.**
+
+### clang-format resources
+  * [Binary builds and source available on the LLVM downloads page](https://releases.llvm.org/download.html)
+  * [Documentation and IDE integration](https://clang.llvm.org/docs/ClangFormat.html)
+
+## About this Driver
+
 Written by Bryan Siepert for Adafruit Industries.
 BSD license, check license.txt for more information
 All text above must be included in any redistribution
-
-To install, use the Arduino Library Manager and search for "Adafruit AS7341" and install the library.

--- a/examples/custom_smux_config/custom_smux_config.ino
+++ b/examples/custom_smux_config/custom_smux_config.ino
@@ -1,0 +1,276 @@
+/* This example shows how to set up custom SMUX configurations for the AS7341 and take measurements with them
+Written by Stephen Fordyce, 24/10/2020
+*/
+
+#include <Adafruit_AS7341.h>
+
+Adafruit_AS7341 as7341;
+//TwoWire myWire2(2);
+uint16_t readings[12];
+#define STANDARD 1
+#define GENERIC 2
+
+void setup() 
+{
+  Serial.begin(115200);
+
+  // Wait for communication with the host computer serial monitor
+  while (!Serial) 
+  {
+    Serial.println("Failed, looping forever");
+    delay(1000);  
+  }
+
+//  myWire2.begin();
+  Wire.begin();
+  delay(20);
+  
+//  if (!as7341.begin(0x39, &myWire2)){ //Use TwoWire I2C port
+  if (!as7341.begin()){ //Default address and I2C port
+    Serial.println("Could not find AS7341");
+    while (1) { delay(10); }
+  }
+  
+  as7341.setATIME(35);
+  as7341.setASTEP(10000); //This combination of ATIME and ASTEP gives an integration time of about 1sec, so with two integrations, that's 2 seconds for a complete set of readings
+  as7341.setGain(AS7341_GAIN_256X);
+}
+
+void loop() 
+{
+  Serial.println("\n\n******Start of tests*****");
+  Serial.println("####Test #1: no option defaults to 2 integrations fixed low and fixed high channels");
+  as7341.startReading();
+  waitGetPrintReadings(STANDARD);
+
+
+  Serial.println("\n\n####Test #2: fixed LOW channels only (1 integration only)");
+  as7341.startReading(AS7341_CH_LOW);
+  waitGetPrintReadings(STANDARD);
+
+  Serial.println("\n####Test #2A: same channels, but setup using custom SMUX (1 integration only)");
+  makeCustomSMUXLowConfig();
+  as7341.startReading(AS7341_CUSTOM_SMUX);
+  waitGetPrintReadings(GENERIC);
+
+  Serial.println("\n####Test #2B: same channels, but setup using custom SMUX and config words (1 integration only)");
+  makeConfigWordCustomSMUXLowConfig();
+  as7341.startReading(AS7341_CUSTOM_SMUX);
+  waitGetPrintReadings(GENERIC);
+  
+  Serial.println();
+  Serial.println("For the 'Low' configuration, the SMUX was set (by different ways), with corresponding values:");
+  as7341.printLocalSMUXConfig();
+  Serial.println();
+  printConfigWords();
+  Serial.println("****Note that the 23 bits used in the config word correspond to (arbitrary) indexes, NOT pixels****");
+
+
+  Serial.println("\n\n####Test #3: fixed HIGH channels only");
+  as7341.startReading(AS7341_CH_HIGH);
+  waitGetPrintReadings(STANDARD);
+
+  Serial.println("\n####Test #3A: same channels, but setup using custom SMUX (1 integration only)");
+  makeCustomSMUXHighConfig();
+  as7341.startReading(AS7341_CUSTOM_SMUX);
+  waitGetPrintReadings(GENERIC);
+
+  Serial.println("\n####Test #3B: same channels, but setup using custom SMUX and config words (1 integration only)");
+  makeConfigWordCustomSMUXHighConfig();
+  as7341.startReading(AS7341_CUSTOM_SMUX);
+  waitGetPrintReadings(GENERIC);
+
+  Serial.println();
+  Serial.println("For the 'High' configuration, the SMUX was set (by different ways), with corresponding values:");
+  as7341.printLocalSMUXConfig();
+  Serial.println();
+  printConfigWords();
+  Serial.println("****Note that the 23 bits used in the config word correspond to (arbitrary) indexes, NOT pixels****");
+
+
+  Serial.println("\nEnd of tests (looping forever)");
+  while(1)
+    delay(50);
+}  
+
+void makeCustomSMUXLowConfig()
+{  
+  as7341.clearSMUXPixelRegistersLocal();  //Start with a fresh canvas
+  as7341.updateSMUXEntryLocal(F1_LEFT, ADC0); //Connect photodiodes to ADC channels
+  as7341.updateSMUXEntryLocal(F1_RIGHT, ADC0);
+  as7341.updateSMUXEntryLocal(F2_LEFT, ADC1);
+  as7341.updateSMUXEntryLocal(F2_RIGHT, ADC1);
+  as7341.updateSMUXEntryLocal(F3_LEFT, ADC2);
+  as7341.updateSMUXEntryLocal(F3_RIGHT, ADC2);
+  as7341.updateSMUXEntryLocal(F4_LEFT, ADC3);
+  as7341.updateSMUXEntryLocal(F4_RIGHT, ADC3);
+  as7341.updateSMUXEntryLocal(FX_CLEAR_LEFT, ADC4);
+  as7341.updateSMUXEntryLocal(FX_CLEAR_RIGHT, ADC4);
+  as7341.updateSMUXEntryLocal(FX_NIR, ADC5);
+  //No need to write to the device, this is taken care of when starting integration
+}
+
+void makeCustomSMUXHighConfig()
+{  
+  as7341.clearSMUXPixelRegistersLocal();  //Start with a fresh canvas
+  as7341.updateSMUXEntryLocal(F5_LEFT, ADC0); //Connect photodiodes to ADC channels
+  as7341.updateSMUXEntryLocal(F5_RIGHT, ADC0);
+  as7341.updateSMUXEntryLocal(F6_LEFT, ADC1);
+  as7341.updateSMUXEntryLocal(F6_RIGHT, ADC1);
+  as7341.updateSMUXEntryLocal(F7_LEFT, ADC2);
+  as7341.updateSMUXEntryLocal(F7_RIGHT, ADC2);
+  as7341.updateSMUXEntryLocal(F8_LEFT, ADC3);
+  as7341.updateSMUXEntryLocal(F8_RIGHT, ADC3);
+  as7341.updateSMUXEntryLocal(FX_CLEAR_LEFT, ADC4);
+  as7341.updateSMUXEntryLocal(FX_CLEAR_RIGHT, ADC4);
+  as7341.updateSMUXEntryLocal(FX_NIR, ADC5);
+  
+  //No need to write to the device, this is taken care of when starting integration
+}
+
+void makeConfigWordCustomSMUXLowConfig()
+{  
+  //NOTE: must use "ADC0" macro instead of "0", they are different! 
+  as7341.setSMUXADCFromConfigWord(ADC0, 0); //Set ADC0 to have no photodiodes
+  as7341.setSMUXADCFromConfigWord(ADC1, CWORD_NONE);  //Set ADC1 to no photo diodes using pre-defined macro
+  as7341.clearSMUXPixelRegistersLocal();  //Just blank all the ADCs
+
+  //Set ADCx photodiodes according to config words generated from as7341.getSMUXConfigWordForADC(ADC0);
+  as7341.setSMUXADCFromConfigWord(ADC0, 131074); //Same as CWORD_BOTH_F1
+  as7341.setSMUXADCFromConfigWord(ADC1, 2080);  //Same as CWORD_BOTH_F2
+  
+  //Set ADCx photodiodes using pre-defined word macros
+  as7341.setSMUXADCFromConfigWord(ADC2, CWORD_BOTH_F3); 
+  as7341.setSMUXADCFromConfigWord(ADC3, CWORD_BOTH_F4);
+  as7341.setSMUXADCFromConfigWord(ADC4, CWORD_BOTH_CLEAR);
+  as7341.setSMUXADCFromConfigWord(ADC5, CWORD_NIR); 
+  
+  //No need to write to the device, this is taken care of when starting integration
+}
+
+void makeConfigWordCustomSMUXHighConfig()
+{  
+  //NOTE: must use "ADC0" macro instead of "0", they are different!
+  as7341.setSMUXADCFromConfigWord(ADC0, 0); //Set ADC0 to have no photodiodes
+  as7341.setSMUXADCFromConfigWord(ADC1, CWORD_NONE);  //Set ADC1 to no photo diodes using pre-defined macro
+  as7341.clearSMUXPixelRegistersLocal();  //Just blank all the ADCs
+
+  //Set ADCx photodiodes according to config words generated from as7341.getSMUXConfigWordForADC(ADC0);
+  as7341.setSMUXADCFromConfigWord(ADC0, 576); //Same as CWORD_BOTH_F5
+  as7341.setSMUXADCFromConfigWord(ADC1, 8200);  //Same as CWORD_BOTH_F6
+  
+  //Set ADCx photodiodes using pre-defined word macros
+  as7341.setSMUXADCFromConfigWord(ADC2, CWORD_BOTH_F7); 
+  as7341.setSMUXADCFromConfigWord(ADC3, CWORD_BOTH_F8);
+  as7341.setSMUXADCFromConfigWord(ADC4, CWORD_BOTH_CLEAR);
+  as7341.setSMUXADCFromConfigWord(ADC5, CWORD_NIR); 
+  //No need to write to the device, this is taken care of when starting integration
+}
+
+void printConfigWords()
+{  
+  Serial.println("Generated SMUX Config words (uin32_t):");
+  int thisADC = 0;
+  uint32_t thisConfigWord = 0;
+  for(int i=0; i<6; i++)
+  {  
+    switch(i)
+    {
+      case(0): {thisADC = ADC0; break;}
+      case(1): {thisADC = ADC1; break;}
+      case(2): {thisADC = ADC2; break;}
+      case(3): {thisADC = ADC3; break;}
+      case(4): {thisADC = ADC4; break;}
+      case(5): {thisADC = ADC5; break;}
+      default: {thisADC = ADC_DISABLED; break;}
+    }
+    thisConfigWord = as7341.getSMUXConfigWordForADC(thisADC);
+    Serial.printf("ADC%d: %lu,\t0x%08X,\t0b", i, thisConfigWord, thisConfigWord);  
+    as7341.printBits(thisConfigWord,32);  //Note this helper function will print anything that's fed to it, even though it belongs to the object
+    Serial.println();
+  }
+}
+
+void waitGetPrintReadings(int option)
+{
+  bool timeOutFlag = false;
+  while(!as7341.checkReadingProgress() && !timeOutFlag ) //Wait for reading
+  {
+    timeOutFlag = yourTimeOutCheck();
+    if(timeOutFlag)
+    {} //Recover/restart/retc.
+    delay(50);
+  }    
+  Serial.println("Here are the readings:");
+  //IMPORTANT: make sure readings is a uint16_t array of size 12, otherwise strange things may happen
+  as7341.getAllChannels(readings);  //Calling this any other time may give you old data
+  if(option == STANDARD)
+    printStandardReadings();
+  if(option == GENERIC)
+    printGenericReadings();
+}
+
+bool yourTimeOutCheck()
+{
+  //Fill this in to prevent the possibility of getting stuck forever if you missed the result, or whatever
+  return false;
+}
+
+void printStandardReadings()
+{
+  Serial.print("Int#1, ADC0 (F1/415nm) : ");
+  Serial.println(readings[0]);
+  Serial.print("Int#1, ADC1 (F2/445nm) : ");
+  Serial.println(readings[1]);
+  Serial.print("Int#1, ADC2 (F3 480nm) : ");
+  Serial.println(readings[2]);
+  Serial.print("Int#1, ADC3 (F4 515nm) : ");
+  Serial.println(readings[3]);
+  // Consider skipping the first set of duplicate clear/NIR readings
+  Serial.print("Int#1, ADC4 (Clear)    : ");
+  Serial.println(readings[4]);
+  Serial.print("Int#1, ADC5 (NIR)      : ");
+  Serial.println(readings[5]);
+
+  Serial.print("Int#2, ADC0 (F5 555nm) : ");
+  Serial.println(readings[6]);
+  Serial.print("Int#2, ADC1 (F6 590nm) : ");
+  Serial.println(readings[7]);
+  Serial.print("Int#2, ADC2 (F7 630nm) : ");
+  Serial.println(readings[8]);
+  Serial.print("Int#2, ADC3 (F8 680nm) : ");
+  Serial.println(readings[9]);
+  Serial.print("Int#2, ADC4 (Clear)    : ");
+  Serial.println(readings[10]);
+  Serial.print("Int#2, ADC5 (NIR)      : ");
+  Serial.println(readings[11]);
+}
+
+void printGenericReadings()
+{
+  Serial.print("Int#1, ADC0 : ");
+  Serial.println(readings[0]);
+  Serial.print("Int#1, ADC1 : ");
+  Serial.println(readings[1]);
+  Serial.print("Int#1, ADC2 : ");
+  Serial.println(readings[2]);
+  Serial.print("Int#1, ADC3 : ");
+  Serial.println(readings[3]);
+  Serial.print("Int#1, ADC4 : ");
+  Serial.println(readings[4]);
+  Serial.print("Int#1, ADC5 : ");
+  Serial.println(readings[5]);
+
+  Serial.print("Int#2, ADC0 : ");
+  Serial.println(readings[6]);
+  Serial.print("Int#2, ADC1 : ");
+  Serial.println(readings[7]);
+  Serial.print("Int#2, ADC2 : ");
+  Serial.println(readings[8]);
+  Serial.print("Int#2, ADC3 : ");
+  Serial.println(readings[9]);
+  Serial.print("Int#2, ADC4 : ");
+  Serial.println(readings[10]);
+  Serial.print("Int#2, ADC5 : ");
+  Serial.println(readings[11]);
+}

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit AS7341
-version=1.1.3
+version=1.2.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for the AS7341 sensors in the Adafruit shop

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit AS7341
-version=1.1.2
+version=1.1.3
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for the AS7341 sensors in the Adafruit shop


### PR DESCRIPTION
I've added a bunch of functions to abstract the complicated stuff away from setting custom SMUX configurations.  These can also be saved as uint32_t config "words" for each ADC.  Pretty heavy stuff, but I have have double checked all the underlying definitions against the SMUX datasheet and am confident in them.

There is also an optional argument added to the startReading() function (and changes to the checkReadingProgress() function), which will run the two integrations with low and high channels (as it previously did), or a single integration of high, low, or a custom SMUX configuration.

There is a detailed example showing how everything works.  I don't have hardware to test it exactly as it is, I tested it on something a little more complex (although it does at least compile for me).  A confirmation that it works for someone else would be appreciated.

It should be noted that it's important to use the macros rather than numbers.  Ie. PIXEL1 != 1, and ADC0 != 0.  It occurs to me that this could be protected against by enumerated custom types, but given it's an advanced functionality, and there is array referencing/indexes involved, I think it best to leave as-is.
