### PR TITLE
Replaced incorrect comment at line 1

### DIFF
--- a/examples/gpio_input_example/gpio_input_example.ino
+++ b/examples/gpio_input_example/gpio_input_example.ino
@@ -1,4 +1,7 @@
-/* This example will use the GPIO pin to blink an led */
+/*
+ * This example uses the GPIO pin to read a digital
+ * logic level from an external source and print the result.
+ */
 
 #include <Adafruit_AS7341.h>
 


### PR DESCRIPTION
This replaces the comment on line 1 of the original file.  That comment may have been mistakenly pasted from the AS7341 GPIO output example.