### PR TITLE
added saturation check functions

### DIFF
--- a/Adafruit_AS7341.cpp
+++ b/Adafruit_AS7341.cpp
@@ -720,11 +720,34 @@ bool Adafruit_AS7341::spectralHighTriggered(void) {
 bool Adafruit_AS7341::getIsDataReady() {
   Adafruit_BusIO_Register status2_reg =
       Adafruit_BusIO_Register(i2c_dev, AS7341_STATUS2);
-  Adafruit_BusIO_RegisterBits avalid_bit =
-      Adafruit_BusIO_RegisterBits(&status2_reg, 1, 6);
+  uint8_t sreg2 = status2_reg.read();
+  _saturationState = 
+    sreg2 & (AS7341_DIGITAL_SATURATION_MSK | AS7341_ANALOG_SATURATION_MSK);
 
-  return avalid_bit.read();
+  return sreg2 & 0x01<<6;
 }
+
+/**
+ * @brief Retruns true if the analog sensor is saturated. This may happen if
+ * the gain is too high.  Result is valid for the most recent completed read.
+ *
+ * @return true: analog sensor has saturated false: has not saturated
+ */
+bool Adafruit_AS7341::getIsAnalogSaturated() {
+  return _saturationState & AS7341_ANALOG_SATURATION_MSK;
+}
+
+/**
+ * @brief Returns true if the digital count has saturated.  This may happen if
+ * the integration time too high.  Result is valid for the most recent 
+ * completed read.
+ *
+ * @return true: Digital count has saturated false: has not saturated
+ */
+bool Adafruit_AS7341::getIsDigitalSaturated() {
+  return _saturationState & AS7341_DIGITAL_SATURATION_MSK;
+}
+
 
 /**
  * @brief Configure SMUX for sensors F1-4, Clear and NIR

--- a/Adafruit_AS7341.h
+++ b/Adafruit_AS7341.h
@@ -148,6 +148,11 @@
 #define AS7341_SPECTRAL_INT_LOW_MSK                                            \
   0b00010000 ///< bitmask to check for a low threshold interrupt
 
+#define AS7341_ANALOG_SATURATION_MSK                                           \
+  1<<3 ///<bitmask to check for sensor saturation
+#define AS7341_DIGITAL_SATURATION_MSK                                          \
+  1<<4 ///<bitmask to check for digital count saturation
+
 /**
  * @brief Allowable gain multipliers for `setGain`
  *
@@ -325,6 +330,9 @@ public:
   bool getGPIOValue(void);
   bool setGPIOValue(bool);
 
+  bool Adafruit_AS7341::getIsDigitalSaturated();
+  bool Adafruit_AS7341::getIsAnalogSaturated();
+
 protected:
   virtual bool _init(int32_t sensor_id);
   uint8_t last_spectral_int_source =
@@ -342,6 +350,7 @@ private:
   void writeRegister(byte addr, byte val);
   void setSMUXLowChannels(bool f1_f4);
   uint16_t _channel_readings[12];
+  uint8_t _saturationState;
   as7341_waiting_t _readingState;
 };
 


### PR DESCRIPTION

Added two functions to check if the last readings were analog or digital saturated.  This will help when checking if gains and integration time are appropriate especially if the light source has changed.  This should not change how any code already written works.  It does add a byte of memory usage and a few cycles when polling for a result.  It does not add any additional bus transactions as the flag bits were already being read but not saved or used. 

I've done my best to make the code consistent with the rest of the library.
 
