### PR TITLE
Fix getTINT() return

### DIFF
--- a/Adafruit_AS7341.cpp
+++ b/Adafruit_AS7341.cpp
@@ -930,8 +930,8 @@ as7341_gain_t Adafruit_AS7341::getGain() {
  * @return long The current integration time in ms
  */
 long Adafruit_AS7341::getTINT() {
-  uint16_t astep = getASTEP();
-  uint8_t atime = getATIME();
+  long astep = getASTEP();
+  long atime = getATIME();
 
   return (atime + 1) * (astep + 1) * 2.78 / 1000;
 }


### PR DESCRIPTION
For #27.

Just changes local variable types to `long` to match return.

Fixes issue on UNO. Some output from example sketch in issue thread:
```
Current ATIME for sensor : 200
Current ASTEP for sensor : 600
Current GAIN for sensor : 1
Current TINT (ms) for sensor : 335
TINT calculated 335
Reading ADC4/Clear    : 45
Basic counts ADC4/Clear    : 0.13
Basic counts semi manual for sensor : 0.00
Basic counts manual for sensor : 0.00
Current ATIME for sensor : 225
Current ASTEP for sensor : 600
Current GAIN for sensor : 1
Current TINT (ms) for sensor : 377
TINT calculated 377
Reading ADC4/Clear    : 51
Basic counts ADC4/Clear    : 0.14
Basic counts semi manual for sensor : 0.00
Basic counts manual for sensor : 0.00
Current ATIME for sensor : 250
Current ASTEP for sensor : 600
Current GAIN for sensor : 1
Current TINT (ms) for sensor : 419
TINT calculated 419
Reading ADC4/Clear    : 57
Basic counts ADC4/Clear    : 0.14
Basic counts semi manual for sensor : 0.00
Basic counts manual for sensor : 0.00
```

Focusing on lines that matter, for example, these two lines agree now:
```
Current TINT (ms) for sensor : 419
TINT calculated 419
```